### PR TITLE
Add Terraform infrastructure for dashboard deployment

### DIFF
--- a/Infra/main.tf
+++ b/Infra/main.tf
@@ -1,0 +1,121 @@
+terraform {
+  required_version = ">= 1.4.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_security_group" "app" {
+  name        = "${var.project_name}-sg"
+  description = "Security group for the CI/CD Health Dashboard"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description = "Frontend"
+    from_port   = 3000
+    to_port     = 3000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description = "Backend"
+    from_port   = 4000
+    to_port     = 4000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  dynamic "ingress" {
+    for_each = var.ssh_allowed_cidrs
+    content {
+      description = "SSH"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+    }
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-sg"
+  }
+}
+
+locals {
+  subnet_id = element(data.aws_subnets.default.ids, 0)
+}
+
+resource "aws_instance" "app" {
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = var.instance_type
+  subnet_id                   = local.subnet_id
+  vpc_security_group_ids      = [aws_security_group.app.id]
+  associate_public_ip_address = true
+  key_name                    = var.key_pair_name
+
+  user_data = templatefile("${path.module}/userdata.sh.tpl", {
+    project_name    = var.project_name
+    app_repo_url    = var.app_repository_url
+    app_branch      = var.app_branch
+    linux_user      = var.instance_ssh_user
+    app_env_content = var.app_env_content
+  })
+
+  tags = {
+    Name = "${var.project_name}-ec2"
+  }
+}

--- a/Infra/outputs.tf
+++ b/Infra/outputs.tf
@@ -1,0 +1,14 @@
+output "instance_public_ip" {
+  description = "Public IP address of the EC2 instance"
+  value       = aws_instance.app.public_ip
+}
+
+output "frontend_url" {
+  description = "Base URL for accessing the frontend"
+  value       = "http://${aws_instance.app.public_ip}:3000"
+}
+
+output "backend_url" {
+  description = "Base URL for accessing the backend API"
+  value       = "http://${aws_instance.app.public_ip}:4000"
+}

--- a/Infra/terraform.tfvars.example
+++ b/Infra/terraform.tfvars.example
@@ -1,0 +1,13 @@
+# Copy this file to terraform.tfvars and adjust the values before applying Terraform
+project_name        = "ci-cd-health-dashboard"
+aws_region          = "us-east-1"
+instance_type       = "t3.micro"
+# key_pair_name     = "your-existing-keypair" # Uncomment to enable SSH with an existing key pair
+ssh_allowed_cidrs   = ["0.0.0.0/0"]
+app_repository_url  = "https://github.com/your-org/ci-cd-health-dashboard.git"
+app_branch          = "main"
+app_env_content = <<EOT
+DATABASE_URL=postgresql://postgres:postgres@db:5432/pipeline
+JWT_SECRET=replace-me
+PORT=4000
+EOT

--- a/Infra/userdata.sh.tpl
+++ b/Infra/userdata.sh.tpl
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euxo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y docker.io docker-compose-plugin git
+
+systemctl enable docker
+systemctl start docker
+
+if id "${linux_user}" &>/dev/null; then
+  usermod -aG docker "${linux_user}" || true
+fi
+
+APP_DIR="/opt/${project_name}"
+REPO_DIR="${APP_DIR}/app"
+
+mkdir -p "${APP_DIR}"
+cd "${APP_DIR}"
+
+if [ ! -d "${REPO_DIR}" ]; then
+  git clone --branch "${app_branch}" "${app_repo_url}" app
+else
+  cd "${REPO_DIR}"
+  git fetch origin "${app_branch}"
+  git reset --hard "origin/${app_branch}"
+  cd "${APP_DIR}"
+fi
+
+cd "${REPO_DIR}"
+
+cat <<'EOCONFIG' > .env
+${app_env_content}
+EOCONFIG
+
+chown -R "${linux_user}:${linux_user}" "${APP_DIR}" || true
+
+/usr/bin/docker compose down --remove-orphans || true
+/usr/bin/docker compose pull || true
+/usr/bin/docker compose up -d --build

--- a/Infra/variables.tf
+++ b/Infra/variables.tf
@@ -1,0 +1,56 @@
+variable "project_name" {
+  description = "Name prefix used for tagging resources"
+  type        = string
+  default     = "ci-cd-health-dashboard"
+}
+
+variable "aws_region" {
+  description = "AWS region where the infrastructure will be created"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type to provision"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "key_pair_name" {
+  description = "Optional existing EC2 key pair name to associate with the instance"
+  type        = string
+  default     = null
+}
+
+variable "instance_ssh_user" {
+  description = "Linux user that Terraform should configure for Docker access"
+  type        = string
+  default     = "ubuntu"
+}
+
+variable "ssh_allowed_cidrs" {
+  description = "List of CIDR blocks allowed to reach the instance via SSH. Leave empty to disable SSH access."
+  type        = list(string)
+  default     = []
+}
+
+variable "app_repository_url" {
+  description = "Git URL of the ci-cd-health-dashboard repository"
+  type        = string
+}
+
+variable "app_branch" {
+  description = "Git branch to deploy"
+  type        = string
+  default     = "main"
+}
+
+variable "app_env_content" {
+  description = "Content for the app .env file used by docker-compose"
+  type        = string
+  default     = <<EOT
+DATABASE_URL=postgresql://postgres:postgres@db:5432/pipeline
+JWT_SECRET=supersecretjwtkey
+PORT=4000
+EOT
+}

--- a/deployment.md
+++ b/deployment.md
@@ -1,0 +1,73 @@
+# CI/CD Health Dashboard Deployment Guide
+
+This guide explains how to provision infrastructure with Terraform and deploy the CI/CD Health Dashboard so that it is publicly reachable over HTTP. The Terraform code lives in the [`Infra`](Infra) directory and provisions an EC2 instance, installs Docker, clones the application repository, and starts the Docker Compose stack.
+
+## Prerequisites
+
+1. **AWS account & credentials**
+   - Configure credentials via `aws configure`, environment variables, or an AWS profile that Terraform can use.
+   - Ensure you have permissions to manage EC2, VPC, IAM, and related networking resources.
+2. **Terraform v1.4+** installed locally.
+3. **Existing EC2 key pair (optional but recommended)** if you need SSH access for troubleshooting. Record the key pair name and the path to the private key.
+4. **Accessible Git repository** that hosts this project. The EC2 instance clones the repository defined by `app_repository_url`.
+
+## Prepare configuration
+
+1. Copy the sample variables file and adjust it:
+   ```bash
+   cp Infra/terraform.tfvars.example Infra/terraform.tfvars
+   ```
+2. Update `Infra/terraform.tfvars`:
+   - `project_name`: Name prefix for tagging resources.
+   - `aws_region`: AWS region to deploy into.
+   - `instance_type`: Instance size (defaults to `t3.micro`).
+   - `key_pair_name`: Uncomment and set if you created an EC2 key pair.
+   - `ssh_allowed_cidrs`: Restrict to trusted networks if SSH is enabled.
+   - `app_repository_url`: Git URL of your CI/CD Health Dashboard repository.
+   - `app_branch`: Branch to deploy.
+   - `app_env_content`: Environment variables written to `.env` before `docker compose up`. Update secrets such as `JWT_SECRET`.
+3. (Optional) Review [`Infra/userdata.sh.tpl`](Infra/userdata.sh.tpl) if you want to customize the bootstrap script.
+
+## Deploy infrastructure
+
+Run the following commands from the repository root:
+
+```bash
+cd Infra
+terraform init
+terraform plan
+terraform apply
+```
+
+Confirm the plan and wait for the apply to finish. Terraform outputs the EC2 public IP along with the frontend and backend URLs.
+
+## Access the application
+
+Once Terraform finishes, the Docker Compose stack will take a few minutes to download images, build the frontend/backend, and start the containers. Afterwards, browse to the frontend URL reported in the Terraform outputs (default `http://<public-ip>:3000`). The backend API is exposed on port 4000 if you need to test it directly.
+
+## Updating the deployment
+
+- **Redeploy latest code**: Run `terraform apply` again after pushing changes to the Git branch specified in `app_branch`. The userdata script will fetch the newest commit and restart the Compose stack.
+- **Changing environment variables**: Edit `app_env_content` in `terraform.tfvars` and re-run `terraform apply`. Terraform will reprovision the instance to apply the new configuration. For small tweaks without reprovisioning, SSH to the instance and modify `/opt/<project-name>/app/.env`, then run `docker compose up -d`.
+- **Scaling**: Increase `instance_type` or duplicate the module in Terraform if you need multiple nodes. For production-grade deployments consider ALB/AutoScaling, remote state, and a managed database instead of the local Postgres container.
+
+## Troubleshooting
+
+- Check EC2 instance logs in the AWS Console or via `journalctl -u cloud-init` to verify the bootstrap script completed successfully.
+- SSH into the instance (if enabled) to inspect Docker services:
+  ```bash
+  ssh -i path/to/key.pem ubuntu@<public-ip>
+  sudo docker compose -f /opt/<project-name>/app/docker-compose.yml ps
+  ```
+- Ensure the security group allows inbound traffic from your network to ports 3000/4000 (and 22 if SSH is enabled).
+
+## Tear down
+
+When you no longer need the infrastructure:
+
+```bash
+cd Infra
+terraform destroy
+```
+
+Terraform will remove the EC2 instance, security group, and associated resources, freeing up AWS costs.

--- a/prompts.md
+++ b/prompts.md
@@ -1,0 +1,8 @@
+# Prompt Log
+
+| Timestamp (UTC) | Role    | Prompt / Action |
+| --------------- | ------- | --------------- |
+| 2025-09-22      | User    | "Write a Terraform to create this ci-cd-health-dashboard, Use Terraform to install Docker + deploy your containerized app..." |
+| 2025-09-22      | System  | "You are ChatGPT, a large language model trained by OpenAI..." |
+
+_No additional AI prompts were used beyond those recorded above._


### PR DESCRIPTION
## Summary
- add Terraform configuration that provisions networking, security groups, and an EC2 host for the CI/CD health dashboard
- bootstrap the instance with Docker, clones the repository, and launches the Docker Compose stack via userdata
- document deployment steps and record the AI prompt log per requirements

## Testing
- not run (Terraform CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d108cf0af8832380caaa4fae045d7f